### PR TITLE
WIP: Fix tag_suffix problems in latest release.

### DIFF
--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -235,6 +235,9 @@ class VersionTagger(ConfigObject):
             if not found_changelog and line.startswith("%changelog"):
                 found_changelog = True
 
+                # WARNING: This is the last tag, minus the assumed "PKGNAME-" prefix. This complicates
+                # the appearance that we can control the package name in the tag with a custom tag_format,
+                # at present we cannot. (as it would break old/existing package metadata files)
                 old_version = get_latest_tagged_version(self.project_name)
                 debug("Got old_version: %s" % old_version)
 
@@ -258,7 +261,7 @@ class VersionTagger(ConfigObject):
                         write(fd, "\n")
                 else:
                     if old_version is not None:
-                        last_tag = self._get_new_tag(old_version)
+                        last_tag = "%s-%s" % (self.project_name, old_version)
                         debug("last_tag = %s" % last_tag)
                         output = self._generate_default_changelog(last_tag)
                     else:

--- a/test/functional/custom_tag_tests.py
+++ b/test/functional/custom_tag_tests.py
@@ -58,15 +58,12 @@ class VersionTaggerTest(unittest.TestCase):
         tito("init")
         run_command('sed -i "s;tagger.*;tagger = tito.tagger.VersionTagger;g" .tito/tito.props')
         run_command('echo "offline = true" >> .tito/tito.props')
-        run_command('echo "tag_format = {component}-v{version}" >> .tito/tito.props')
         run_command('git add .tito/tito.props')
         run_command("git commit -m 'set offline in tito.props'")
 
         # Init RPM package
         self.create_rpm_package()
 
-        # Run tito release
-        tito("tag release --accept-auto-changelog")
 
     def write_file(self, path, contents):
         out_f = open(path, 'w')
@@ -83,5 +80,16 @@ class VersionTaggerTest(unittest.TestCase):
         """
         Check that the tag is correct
         """
+        # Run tito tag
+        run_command('echo "tag_format = {component}-v{version}" >> .tito/tito.props')
+        tito("tag --accept-auto-changelog")
         latest_tag = getoutput("git describe --abbrev=0 --tags")
-        assert latest_tag == 'hello_tito-v0.1.8'
+        self.assertEqual('hello_tito-v0.1.8', latest_tag)
+        # TODO: test package metadata looks correct
+
+    def test_tag_with_suffix(self):
+        run_command('echo "tag_suffix = .fc1_17" >> .tito/tito.props')
+        tito("tag --accept-auto-changelog")
+        latest_tag = getoutput("git describe --abbrev=0 --tags")
+        self.assertEqual('hello_tito-0.1.8-1.fc1_17', latest_tag)
+        # TODO: test package metadata looks correct

--- a/test/functional/custom_tag_tests.py
+++ b/test/functional/custom_tag_tests.py
@@ -64,7 +64,6 @@ class VersionTaggerTest(unittest.TestCase):
         # Init RPM package
         self.create_rpm_package()
 
-
     def write_file(self, path, contents):
         out_f = open(path, 'w')
         out_f.write(contents)

--- a/test/functional/singleproject_tests.py
+++ b/test/functional/singleproject_tests.py
@@ -14,7 +14,7 @@
 
 import os
 from tito.builder import Builder, UpstreamBuilder
-from tito.common import tag_exists_locally, check_tag_exists
+from tito.common import tag_exists_locally, check_tag_exists, run_command
 from tito.release import Releaser
 from tito.compat import getoutput
 from functional.fixture import TitoGitTestFixture, tito
@@ -57,6 +57,13 @@ class SingleProjectTests(TitoGitTestFixture):
     def test_tag(self):
         tito("tag --accept-auto-changelog --debug")
         check_tag_exists("%s-0.0.2-1" % PKG_NAME, offline=True)
+
+    def test_tag_with_suffix(self):
+        # Append a tag suffix to our global tito.props:
+        run_command('echo "tag_suffix = .fc1_17" >> .tito/tito.props')
+        # Create a 0.0.2 now with the addition of a tag suffix:
+        tito("tag --accept-auto-changelog --debug")
+        check_tag_exists("%s-0.0.2-1.fc1_17" % PKG_NAME, offline=True)
 
     def test_tag_with_version(self):
         tito("tag --accept-auto-changelog --debug --use-version 9.0.0")


### PR DESCRIPTION
Introduction of configurable tag formats has caused some issues particularly for users with a tag_suffix defined in their tito.props. 

Issues identified so far:
- tags are now created with name-version-suffix-release, previously this was name-version-release-suffix.
- changelog generation is broken due to how it interprets the data in .tito/packages/pkgname. Here unfortunately we historically stored version-release-suffix. (note: no package name) This implies to reconstruct the last tag we have to assume a prefix of name-, which means we do not *really *have configurable tag formats, at least not where the packagename- prefix is concerned.

So far this PR exposes both problems with tests and corrects them. We still cannot for example, remove or re-order the packagename- prefix in a tag format.