### PR TITLE
Move tito under rpm-software-management namespace

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -1,24 +1,3 @@
-[yum-f20-x86_64]
-releaser = tito.release.YumRepoReleaser
-builder = tito.builder.MockBuilder
-builder.mock = fedora-20-x86_64
-srpm_disttag = .fc20
-rsync = fedorapeople.org:/srv/repos/dgoodwin/tito/fedora-20/x86_64/ fedorapeople.org:/srv/repos/dgoodwin/tito/fedora-20/i386/
-
-[yum-f21-x86_64]
-releaser = tito.release.YumRepoReleaser
-builder = tito.builder.Builder
-builder.mock = fedora-21-x86_64
-srpm_disttag = .fc21
-rsync = fedorapeople.org:/srv/repos/dgoodwin/tito/fedora-21/x86_64/ fedorapeople.org:/srv/repos/dgoodwin/tito/fedora-21/i386/
-
-[yum-el6-x86_64]
-releaser = tito.release.YumRepoReleaser
-builder = tito.builder.MockBuilder
-builder.mock = epel-6-x86_64
-srpm_disttag = .el6
-rsync = fedorapeople.org:/srv/repos/dgoodwin/tito/epel-6/x86_64/ fedorapeople.org:/srv/repos/dgoodwin/tito/epel-6/i386/
-
 [test-koji]
 releaser = tito.release.KojiReleaser
 autobuild_tags = tag1 tag2
@@ -32,7 +11,6 @@ git_url = git://example.com
 releaser = tito.release.FedoraGitReleaser
 branches = master el6 epel7 epel8 f30 f31 f32
 
-[copr-dgoodwin]
+[copr]
 releaser = tito.release.CoprReleaser
-project_name = tito
-
+project_name = @rpm-software-management/tito

--- a/HACKING.md
+++ b/HACKING.md
@@ -2,7 +2,7 @@ Hacking
 =======
 
 This is the developer documentation for
-https://github.com/dgoodwin/tito
+https://github.com/rpm-software-management/tito
 
 Python versions
 ---------------

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ From git's `master` branch:
   https://pip.pypa.io/en/stable/user_guide/#user-installs) (i.e. isolated to the
   current user):
 
-      pip install --user https://github.com/dgoodwin/tito/archive/master.tar.gz
+      pip install --user https://github.com/rpm-software-management/tito/archive/master.tar.gz
 
 To make an rpm of tito to install elsewhere
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -34,7 +34,7 @@ Tito offers the following features:
 To install from source
 
 ```
-$ git clone https://github.com/dgoodwin/tito.git
+$ git clone https://github.com/rpm-software-management/tito.git
 $ cd tito/
 $ sudo yum install python-setuptools
 $ ./setup.py build
@@ -225,6 +225,6 @@ See:
 * `man 5 titorc`
 
 ## External Docs
-* [Tito release announcements](http://rm-rf.ca/blogs/dgoodwin)
+* [Tito release announcements](https://github.com/rpm-software-management/tito/releases)
 * [How to create new release of RPM package in 5 seconds](http://miroslav.suchy.cz/blog/archives/2013/12/17/how_to_create_new_release_of_rpm_package_in_5_seconds)
 * [How to build in Copr](http://miroslav.suchy.cz/blog/archives/2013/12/29/how_to_build_in_copr)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Tito
-repo_url: https://github.com/dgoodwin/tito
+repo_url: https://github.com/rpm-software-management/tito
 docs_dir: doc
 markdown_extensions:
   - codehilite

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,8 @@ setup(
     name="tito",
     version='0.6.13',
     description='A tool for managing rpm based git projects.',
-    author='Devan Goodwin',
-    author_email='dgoodwin@rm-rf.ca',
-    url='http://rm-rf.ca/tito',
+    author='rpm-software-management',
+    url='https://github.com/rpm-software-management/tito',
     license='GPLv2+',
 
     # tell distutils packages are under src directory

--- a/tito.spec
+++ b/tito.spec
@@ -21,9 +21,9 @@ Release: 1%{?dist}
 Summary: A tool for managing rpm based git projects
 
 License: GPLv2
-URL: https://github.com/dgoodwin/tito
+URL: https://github.com/rpm-software-management/tito
 # Sources can be obtained by
-# git clone https://github.com/dgoodwin/tito.git
+# git clone https://github.com/rpm-software-management/tito
 # cd tito
 # tito build --tgz
 Source0: %{name}-%{version}.tar.gz


### PR DESCRIPTION
We collectively decided to move tito upstream from https://github.com/dgoodwin/tito to https://github.com/rpm-software-management/tito