### PR TITLE
Separate .tito directory creation from tito.props file creation

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -698,14 +698,15 @@ class InitModule(BaseCliModule):
         should_commit = False
 
         rel_eng_dir = os.path.join(find_git_root(), '.tito')
-        print("Creating tito metadata in: %s" % rel_eng_dir)
+        if not os.path.exists(rel_eng_dir):
+            print("Creating tito metadata in: %s" % rel_eng_dir)
+            os.makedirs(rel_eng_dir)
+            print("   - created %s" % rel_eng_dir)
+        else:
+            print("Reinitializing existing tito metadata in %s" % rel_eng_dir)
 
         propsfile = os.path.join(rel_eng_dir, TITO_PROPS)
         if not os.path.exists(propsfile):
-            if not os.path.exists(rel_eng_dir):
-                os.makedirs(rel_eng_dir)
-                print("   - created %s" % rel_eng_dir)
-
             # write out tito.props
             out_f = open(propsfile, 'w')
             out_f.write("[buildconfig]\n")


### PR DESCRIPTION
Fix #158
    
As a consequence we can easily print a different message when running
`tito init` an already initialized tito project.


I am basing this PR on a commit from PR #368 because I wanted to avoid dealing with merge conflicts. Please make sure that #368 gets merged first.