### PR TITLE
Make yes or no input less aggressive

### DIFF
--- a/src/tito/release/main.py
+++ b/src/tito/release/main.py
@@ -102,12 +102,16 @@ class Releaser(ConfigObject):
     def _ask_yes_no(self, prompt="Y/N? ", default_auto_answer=True):
         if self.auto_accept:
             return default_auto_answer
-        else:
-            if PY2:
-                answer = raw_input(prompt)
-            else:
-                answer = input(prompt)
-            return answer.lower() in ['y', 'yes', 'ok', 'sure']
+
+        yes = ['y', 'yes', 'ok', 'sure']
+        no = ['n', 'no', 'nah', 'nope']
+        answers = yes + no
+
+        while True:
+            input_function = raw_input if PY2 else input
+            answer = input_function(prompt).lower()
+            if answer in answers:
+                return answer in yes
 
     def _check_releaser_config(self):
         """

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -25,6 +25,16 @@ is_rawhide = sys.version_info[:2] >= (3, 8)
 is_epel6 = sys.version_info[:2] == (2, 6)
 
 
+if PY2:
+    builtins = "__builtin__"
+    builtins_open = "__builtin__.open"
+    builtins_input = "__builtin__.raw_input"
+else:
+    builtins = "builtins"
+    builtins_open = "builtins.open"
+    builtins_input = "builtins.input"
+
+
 file_spec = None
 
 
@@ -92,11 +102,7 @@ def open_mock(content, **kwargs):
 
     content_out = StringIO()
 
-    if PY2:
-        patch_module = "__builtin__.open"
-    else:
-        patch_module = "builtins.open"
-    with patch(patch_module, m, create=True, **kwargs) as mo:
+    with patch(builtins_open, m, create=True, **kwargs) as mo:
         stream = StringIO(content)
         rv = mo.return_value
         rv.write = lambda x: content_out.write(bytes(x, "utf-8"))

--- a/test/unit/releaser_tests.py
+++ b/test/unit/releaser_tests.py
@@ -1,0 +1,36 @@
+import unittest
+import mock
+from tito.compat import PY2, RawConfigParser
+from tito.release import Releaser
+from unit import builtins_input
+
+
+class ReleaserTests(unittest.TestCase):
+
+    @mock.patch("tito.release.main.create_builder")
+    @mock.patch("tito.release.main.mkdtemp")
+    def setUp(self, mkdtemp, create_builder):
+        self.config = RawConfigParser()
+
+        self.releaser_config = RawConfigParser()
+        self.releaser_config.add_section("test")
+        self.releaser_config.set('test', "releaser",
+            "tito.release.Releaser")
+
+        self.releaser = Releaser("titotestpkg", None, "/tmp/tito/",
+            self.config, {}, "test", self.releaser_config, False,
+            False, False, **{"offline": True})
+
+    @mock.patch(builtins_input)
+    def test_ask_yes_or_no(self, input_mock):
+        input_mock.side_effect = "y"
+        assert self.releaser._ask_yes_no()
+
+        input_mock.side_effect = "n"
+        assert not self.releaser._ask_yes_no()
+
+        input_mock.side_effect = ["yy", "y"]
+        assert self.releaser._ask_yes_no()
+
+        input_mock.side_effect = ["yy", "no"]
+        assert not self.releaser._ask_yes_no()


### PR DESCRIPTION
Fix #364

Previously all non-yes input was considered to be "no". Which is not
what we typically want. There should be expected "yes" inputs, expected
"no" inputs and everything else should be considered to be an uknown
input and should be treated this way.

I think that printing an error for unknown input is too verbose and have
no added value. Simply repeating the question is the way to go here:

    ##### Please review the above diff #####
    Do you wish to proceed with commit? [y/n] foo
    Do you wish to proceed with commit? [y/n] y
    Proceeding with commit.