### PR TITLE
When extra source file exist, then do not copy it

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -504,6 +504,10 @@ class Builder(ConfigObject, BuilderBase):
         sources = getoutput(cmd).split("\n")
 
         for source in sources[1:]:
+            dst_file = os.path.join(self.rpmbuild_sourcedir, source)
+            if os.path.isfile(dst_file):
+                debug('Source file "%s" already exists. Skiping.' % dst_file)
+                continue
             src = os.path.join(self.rpmbuild_sourcedir, self.tgz_dir, source)
             if os.path.islink(src) and os.path.isabs(src):
                 src = os.path.join(self.start_dir, os.readlink(src))


### PR DESCRIPTION
* Extra source file can be copied/moved by some other tool
* When the source file already exists in destination path, then
  do not try to copy it once again
* This issue was observed, when we tried to build
  subscription-manager on Fedora 32 using tito