### PR TITLE
Add Docker support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,4 +12,4 @@ Miroslav Suchý <msuchy@redhat.com>
 
 and: Adam Miller, Alex Wood, Aron Parsons, Brenton Leanhardt, Ivan Nečas, John Eckersberg,
 Kenny MacDermid, Lukáš Zapletal, Luke Meyer, Marian Csontos, Martin Bačovský, Michael Stead,
-Mike McCune, mscherer, Paul Morgan, Sean P. Kane, Steve 'Ashcrow' Milner
+Mike McCune, mscherer, Paul Morgan, Sean P. Kane, Steve 'Ashcrow' Milner, Alexandre 'devodev' Barone

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+ARG CENTOS_VERSION="8.2.2004"
+FROM centos:${CENTOS_VERSION}
+
+# This is used in the entrypoint to set
+# the builder git config
+ENV GIT_USERNAME "user"
+ENV GIT_EMAIL    "user@example.com"
+
+# Update cache and install tito dependencies,
+# as well as the 'Development Tools' package group
+RUN dnf clean all \
+ && dnf -y --setopt="tsflags=nodocs" update \
+ && dnf -y --setopt="tsflags=nodocs" install \
+    which \
+    sudo \
+    git \
+    rpm-build \
+    redhat-rpm-config \
+    rpmdevtools \
+    python36 \
+    maven \
+ && dnf -y --setopt="tsflags=nodocs" group install "Development Tools" \
+ && dnf clean all \
+ && rm -rf /var/cache/dnf
+
+# Install tito from github
+# TODO: add ARG to select version to pull
+RUN mkdir -p /usr/local/lib/python3.6/site-packages \
+ && git clone https://github.com/rpm-software-management/tito.git /tmp/tito-package \
+ && cd /tmp/tito-package \
+ && pip3 install .
+
+# Create builder user and setup environment
+ARG GIT_DOMAIN=github.com
+RUN useradd builder -u 1000 -m -G users,wheel \
+ && echo "builder ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers \
+ && mkdir /workspace \
+ && chown builder:builder /workspace \
+ && mkdir -m 700 -p /home/builder/.ssh \
+ && ssh-keyscan -t rsa "${GIT_DOMAIN}" >> /home/builder/.ssh/known_hosts \
+ && chown -R builder:builder /home/builder/.ssh
+
+# Switch to builder
+USER builder
+
+# Expose the workspace as a volume to let
+# users map a local repository inside the container
+VOLUME /workspace
+
+WORKDIR /workspace
+
+# To build packages without needing to have local repositories,
+# set the GIT_URL environment variable to let
+# the entrypoint clone the repository.
+COPY --chown=builder:builder ./docker-entrypoint.sh /
+RUN chmod 755 /docker-entrypoint.sh
+
+# The entrypoint will install build dependencies using
+# dnf builddep when run using "build" command.
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Find executables
+DNF="sudo $(which dnf)"
+GIT=$(which git)
+TITO=$(which tito)
+
+# Parse args
+[ $# -lt 1 ] && { echo "USAGE: $(basename ${BASH_SOURCE[0]}) <TITO_COMMAND> [ARGS..]" >&2; exit 1; }
+
+TITO_COMMAND=$1; shift
+
+# Set permissions
+sudo chown -R builder:builder /workspace
+
+# Parse env
+echo "Parse env vars"
+git_username="${GIT_USERNAME:-user}"
+git_email="${GIT_EMAIL:-user@example.com}"
+
+echo "Setup git config"
+${GIT} config --global user.name  "${git_username}"
+${GIT} config --global user.email "${git_email}"
+
+# If /workspace is empty, clone GIT_URL inside, or fail if not set.
+if ! [ "$(ls -A /workspace)" ]; then
+    if [ -z "${GIT_URL}" ]; then
+        echo "error: /workspace is empty and GIT_URL not provided." >&2
+        exit 2
+    fi
+    ${GIT} clone "${GIT_URL}" /workspace
+fi
+
+if [ "${TITO_COMMAND}" = "build" ]; then
+    spec="$(find . -maxdepth 1 -type f -name '*.spec' | head -n1)"
+    if [ -z "${spec}" ]; then
+        echo "error: could not find spec file." >&2
+        exit 2
+    fi
+    echo "installing build dependencies"
+    ${DNF} -y builddep --spec "${spec}"
+fi
+
+# Main
+${TITO} "${TITO_COMMAND}" "$@"


### PR DESCRIPTION
**What:**
This PR adds a Dockerfile as well as a docker-entrypoint.sh script to build RPM's with tito on CentOS8.
Documentation has also been added in README.md under the 'Docker' section.

**Why:**
Tito is already providing a way to build RPM packages reliably. This is extending it further!
We have been using something similar internally with great success and I thought it might be helpful to the community.

**Caveats:**
The current Dockerfile relies solely on official CentOS repositories and does not provide a way to add/enable repositories. IMO, it would be fairly easy to add args/environment variables to pass repositories at build or runtime depending on user needs. For us, we were baking our private repositories inside the Dockerfile to leverage layer caches.

**More:**
This is tested with the tito repository itself and confirmed working.

The PR will probably need refining and maybe need to be transitioned to it's own directory if we would want to adapt it to other distros and so on. Same thing with the documentation, which is only 'functional' to say the least.

P.S.: Sorry about the first try, I used the wrong author..