### PR TITLE
Fix copy_extra_sources for remote URLs

### DIFF
--- a/src/tito/compat.py
+++ b/src/tito/compat.py
@@ -25,6 +25,7 @@ if PY2:
     from ConfigParser import NoOptionError
     from ConfigParser import RawConfigParser
     from StringIO import StringIO
+    from urlparse import urlparse
     import xmlrpclib
     text_type = unicode
     binary_type = str
@@ -33,6 +34,7 @@ else:
     from configparser import NoOptionError
     from configparser import RawConfigParser
     from io import StringIO
+    from urllib.parse import urlparse
     import xmlrpc.client as xmlrpclib
     text_type = str
     binary_type = bytes


### PR DESCRIPTION
Fix #387

A build with a remote URL in its `SourceX` will work only with

    %_disable_source_fetch 0

macro defined. It can be done either globally via `~/.rpmmacros` or by
using tito with following parameter

    --rpmbuild-options="--define '%_disable_source_fetch 0'"

IMHO this macro should be set by default but we should also introduce
a switch to turn it off (like e.g. Mock or Copr do). Since it is not
related to fixing #387, I am not doing it in this commit.