### PR TITLE
Make copy_extra_sources method more foolproof

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -517,6 +517,10 @@ class Builder(ConfigObject, BuilderBase):
                 debug('Source "%s" is not a local file. Skiping.' % source)
                 continue
 
+            if not os.path.exists(source):
+                debug('Source "%s" file does not exist. Skiping.' % source)
+                continue
+
             src = os.path.join(self.rpmbuild_sourcedir, self.tgz_dir, source)
             if os.path.islink(src) and os.path.isabs(src):
                 src = os.path.join(self.start_dir, os.readlink(src))

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -499,7 +499,7 @@ class Builder(ConfigObject, BuilderBase):
         """
         Copy extra %{SOURCEX} files to the SOURCE folder.
         """
-        cmd = "spectool -S '%s' --define '_sourcedir %s' | awk '{print $2}'"\
+        cmd = "spectool -S '%s' --define '_sourcedir %s' 2> /dev/null | awk '{print $2}'"\
             % (self.spec_file, self.start_dir)
         sources = getoutput(cmd).split("\n")
 


### PR DESCRIPTION
... by ignoring spectool warnings (and therefore fixing the assumption that each line is a `SourceX` file) and by not trying to copy nonexisting files.