### PR TITLE
Make tests working on systems without non-versioned python macros

### DIFF
--- a/test/functional/build_gitannex_tests.py
+++ b/test/functional/build_gitannex_tests.py
@@ -18,6 +18,7 @@ Functional Tests for the GitAnnexBuilder.
 import os
 import glob
 import tempfile
+import sys
 import shutil
 from nose.plugins.skip import SkipTest
 from os.path import join
@@ -56,7 +57,8 @@ class GitAnnexBuilderTests(TitoGitTestFixture):
                 "true")
 
         os.chdir(self.repo_dir)
-        spec = join(os.path.dirname(__file__), "specs/extsrc.spec")
+        specname = "extsrc-3.spec" if sys.version_info[0] == 3 else "extsrc-2.spec"
+        spec = join(os.path.dirname(__file__), "specs", specname)
         self.create_project_from_spec(PKG_NAME, self.config,
                 spec=spec)
         self.source_filename = 'extsrc-0.0.2.tar.gz'

--- a/test/functional/fetch_tests.py
+++ b/test/functional/fetch_tests.py
@@ -17,6 +17,7 @@ Functional Tests for the FetchBuilder.
 
 import glob
 import os
+import sys
 import shutil
 import tempfile
 
@@ -49,7 +50,11 @@ class FetchBuilderTests(TitoGitTestFixture):
     def setUp(self):
         TitoGitTestFixture.setUp(self)
         self.pkg_dir = join(self.repo_dir, EXT_SRC_PKG)
-        spec = join(os.path.dirname(__file__), "specs/extsrc.spec")
+
+        specname = "extsrc-3.spec" if sys.version_info[0] == 3 else "extsrc-2.spec"
+        spec = join(os.path.dirname(__file__), "specs", specname)
+        shutil.copyfile(spec, os.path.join(self.repo_dir, "extsrc.spec"))
+        spec = join(self.repo_dir, "extsrc.spec")
 
         # Setup test config:
         self.config = RawConfigParser()

--- a/test/functional/specs/extsrc-2.spec
+++ b/test/functional/specs/extsrc-2.spec
@@ -1,0 +1,26 @@
+%{!?python2_sitelib: %define python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+
+Name:           extsrc
+Version:        0.0.1
+Release:        1%{?dist}
+Summary:        tito test package for the external source builder
+URL:            https://example.com
+License:        GPLv2
+Source0:        %{name}-%{version}.tar.gz
+BuildArch:      noarch
+
+%description
+Nobody cares.
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+%defattr(-,root,root)
+
+%changelog

--- a/test/functional/specs/extsrc-3.spec
+++ b/test/functional/specs/extsrc-3.spec
@@ -1,4 +1,4 @@
-%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+%{!?python3_sitelib: %define python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Name:           extsrc
 Version:        0.0.1
@@ -22,7 +22,5 @@ Nobody cares.
 
 %files
 %defattr(-,root,root)
-#%dir %{python_sitelib}/%{name}
-#%{python_sitelib}/%{name}-*.egg-info
 
 %changelog


### PR DESCRIPTION
See RHBZ 1784688

We are using unversioned python macros, such as `%__python` and
`%python_sitelib` which are not supported in Fedora rawhide
anymore. Instead, we should use `%__python3` and `%python3_sitelib`.