### PR TITLE
Added test_version parameter to cli

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -91,6 +91,7 @@ class BuilderBase(object):
         # releasers in their config sections.
         if args and 'test' in args:
             self.test = True
+            self.test_version = self._get_optional_arg(kwargs, 'test_version', 0)
 
         # Location where we do all tito work and store resulting rpms:
         self.rpmbuild_basedir = build_dir
@@ -598,12 +599,12 @@ class Builder(ConfigObject, BuilderBase):
             munge_specfile(
                 self.spec_file,
                 sha,
-                self.commit_count,
+                self.test_version,
                 fullname,
                 self.tgz_filename,
             )
 
-            self.build_version += ".git." + str(self.commit_count) + "." + str(sha)
+            self.build_version += ".git." + str(self.test_version) + "." + str(sha)
             self.ran_setup_test_specfile = True
 
     def _get_rpmbuild_dir_options(self):
@@ -681,11 +682,11 @@ class NoTgzBuilder(Builder):
             # file we're building off. (note that this is a temp copy of the
             # spec) Swap out the actual release for one that includes the git
             # SHA1 we're building for our test package:
-            debug("setup_test_specfile:commit_count = %s" % str(self.commit_count))
+            debug("setup_test_specfile:test_version = %s" % str(self.test_version))
             munge_specfile(
                 self.spec_file,
                 self.git_commit_id[:7],
-                self.commit_count
+                self.test_version
             )
 
 
@@ -1101,7 +1102,7 @@ class MeadBuilder(Builder):
             # file we're building off. (note that this is a temp copy of the
             # spec) Swap out the actual release for one that includes the git
             # SHA1 we're building for our test package:
-            self.build_version += ".git." + str(self.commit_count) + "." + str(self.git_commit_id[:7])
+            self.build_version += ".git." + str(self.test_version) + "." + str(self.git_commit_id[:7])
             replace_spec_release(self.spec_file, self.spec_release)
             self.ran_setup_test_specfile = True
 

--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -327,6 +327,8 @@ class BuildModule(BaseCliModule):
 
         self.parser.add_option("--test", dest="test", action="store_true",
                 help="use current branch HEAD instead of latest package tag")
+        self.parser.add_option("--test-version", dest="test_version", action="store_true",
+                help="overrides the commit count number in the produced artifact name in test build")
         self.parser.add_option("--no-cleanup", dest="no_cleanup",
                 action="store_true",
                 help="do not clean up temporary tito build directories/files, and disable rpmbuild %clean")
@@ -369,6 +371,7 @@ class BuildModule(BaseCliModule):
         kwargs = {
             'dist': self.options.dist,
             'test': self.options.test,
+            'test_version': self.options.test_version,
             'offline': self.options.offline,
             'auto_install': self.options.auto_install,
             'rpmbuild_options': self.options.rpmbuild_options,
@@ -446,6 +449,9 @@ class ReleaseModule(BaseCliModule):
 
         self.parser.add_option("--test", action="store_true",
                 help="use current branch HEAD instead of latest package tag")
+
+        self.parser.add_option("--test_version", action="store_true",
+                help="overrides the commit count number in the produced artifact name in test build")
 
         self.parser.add_option("-y", "--yes", dest="auto_accept", action="store_true",
                 help="Do not require input, just accept commits and builds")
@@ -594,6 +600,7 @@ class ReleaseModule(BaseCliModule):
                 releaser_config=releaser_config,
                 no_cleanup=self.options.no_cleanup,
                 test=self.options.test,
+                test_version=self.options.test_version,
                 auto_accept=self.options.auto_accept,
                 **kwargs)
 

--- a/src/tito/release/main.py
+++ b/src/tito/release/main.py
@@ -53,6 +53,8 @@ class Releaser(ConfigObject):
         config_builder_args = self._parse_builder_args(releaser_config, target)
         if test:
             config_builder_args['test'] = [True]  # builder must know to build from HEAD
+            self.test_version = self._get_optional_arg(kwargs, 'test_version', 0)
+
 
         # Override with builder args from command line if any were given:
         if 'builder_args' in kwargs:


### PR DESCRIPTION
### Changes made:
* Added test_version parameter to cli when used with build --test to produce the test artifact with a desired numbered version rather than using the commit_count which is always 0.
* Kept the default value for the "test_version" as 0.