### PR TITLE
Rename and document the tito.props option for fetching sources

### DIFF
--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -274,8 +274,8 @@ class BaseCliModule(object):
                 "offline"):
             self.options.offline = True
 
-        if self.config.has_option(BUILDCONFIG_SECTION, "fetch-sources"):
-            self.options.fetch_sources = self.config.get(BUILDCONFIG_SECTION, "fetch-sources")
+        if self.config.has_option(BUILDCONFIG_SECTION, "fetch_sources"):
+            self.options.fetch_sources = self.config.get(BUILDCONFIG_SECTION, "fetch_sources")
 
         # TODO: Not ideal:
         if self.options.debug:

--- a/tito.props.5.asciidoc
+++ b/tito.props.5.asciidoc
@@ -94,6 +94,11 @@ other taggers.
 sign_tag::
 This boolean enables GnuPG signed tags using 'git tag -s'.
 
+fetch_sources::
+If true, download sources from predefined Source<N> addresses to the
+SOURCE folder.
+
+
 KOJI and COPR
 -------------
 


### PR DESCRIPTION
Complements PR #407

Every other `tito.props` config option uses underscores instead of
dashes, so let's preserve this convention.

Also describing it in the manpage.