### PR TITLE
DistGitReleasers: don't nuke external sources with fetch_sources

### DIFF
--- a/src/tito/compat.py
+++ b/src/tito/compat.py
@@ -27,6 +27,7 @@ if PY2:
     from ConfigParser import RawConfigParser
     from StringIO import StringIO
     from urlparse import urlparse
+    from urlparse import urlretrieve
     import xmlrpclib
     text_type = unicode
     binary_type = str
@@ -36,6 +37,7 @@ else:
     from configparser import RawConfigParser
     from io import StringIO
     from urllib.parse import urlparse
+    from urllib.request import urlretrieve
     from contextlib import redirect_stdout
     import xmlrpc.client as xmlrpclib
     text_type = str

--- a/src/tito/release/distgit.py
+++ b/src/tito/release/distgit.py
@@ -105,7 +105,7 @@ class FedoraGitReleaser(Releaser):
         # Mead builds need to be in the git_root.  Other builders are agnostic.
         with chdir(self.git_root):
             self.builder.tgz()
-            self.builder.copy_extra_sources()
+            self.builder.copy_and_download_extra_sources()
 
         if self.test:
             self.builder._setup_test_specfile()
@@ -492,7 +492,7 @@ class CentosGitReleaser(FedoraGitReleaser):
         # Mead builds need to be in the git_root.  Other builders are agnostic.
         with chdir(self.git_root):
             self.builder.tgz()
-            self.builder.copy_extra_sources()
+            self.builder.copy_and_download_extra_sources()
 
         if self.test:
             self.builder._setup_test_specfile()


### PR DESCRIPTION
Previously only 'tito build --srpm|--rpm' worked well with fetch_sources
where we rely on RPM's (rpmbuild) built-in download mechanism.  It did
not work well with 'tito release' and DistGit releasers, though.

The thing is that we don't use rpmbuild at all while doing DistGit
releases BUT we still want those files to be (a) downloaded to
%_sourcedir and then (b) uploaded to DistGit lookaside cache.  Because
we did not download those files before, every extra source file was
entirely ignored, or even worse, if the file was already uploaded in
the target lookaside cache, the file was removed from sources.

This bitten us during 'copr-backend' releases several times, and starts
being painful in 'resalloc-aws' releases, too.