### PR TITLE
Remove '-.*' from the end of git-annex version strings.

### DIFF
--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -1045,7 +1045,7 @@ def compare_version(version1, version2):
     zero when equal and positive when version1 > version2.
     """
     def normalize(v):
-        return [int(x) for x in re.sub(r'(\.0+)*$', '', v).split(".")]
+        return [int(x) for x in re.sub(r'(\.0+)*$', '', re.sub(r'(-.*)$', '', v)).split(".")]
     a = normalize(version1)
     b = normalize(version2)
     return (a > b) - (a < b)


### PR DESCRIPTION
RPMs provided by git-annex have a '-{hash}' added to the version, breaking version detection.

This was the simplest way I could come up with to get around this issue, based on what was already implemented.