### PR TITLE
Revert 45d431ad149cb33e2462a990c4c4f29e6bb2bb7e

### DIFF
--- a/src/tito/release/distgit.py
+++ b/src/tito/release/distgit.py
@@ -552,7 +552,7 @@ class DistGitMeadReleaser(DistGitReleaser):
             self.push_url = self.push_url.replace(MEAD_SCM_USERNAME, user)
 
     def _sync_mead_scm(self):
-        cmd = "git push --follow-tags %s %s" % (self.push_url, self.git_branches[0])
+        cmd = "git push %s %s" % (self.push_url, self.builder.build_tag)
 
         if self.dry_run:
             self.print_dry_run_warning(cmd)
@@ -565,9 +565,9 @@ class DistGitMeadReleaser(DistGitReleaser):
             except RunCommandException as e:
                 if "rejected" in e.output:
                     if self._ask_yes_no("The remote rejected a push.  Force push? [y/n] ", False):
-                        run_command("git push --force --follow-tags %s %s" % (self.push_url, self.git_branches[0]))
+                        run_command("git push --force %s %s" % (self.mead_scm, self.builder.build_tag))
                     else:
-                        error_out("Could not sync with %s" % self.push_url)
+                        error_out("Could not sync with %s" % self.mead_scm)
                 raise
 
     def _git_release(self):


### PR DESCRIPTION
- The original change made the assumption that the git_branches[0]
  is the actual branch name that we are on, but that was incorrect.