### PR TITLE
Fix UpstreamBuilder deprecation warning

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -938,7 +938,7 @@ class UpstreamBuilder(NoTgzBuilder):
         lines.insert(patch_insert_index, "Patch%s: %s\n" % (patch_number,
             patch_filename))
         if patch_apply_index > 0:
-            lines.insert(patch_apply_index, "%%patch%s -p1\n" % (patch_number))
+            lines.insert(patch_apply_index, "%%patch %s -p1\n" % (patch_number))
         self._write_spec(lines)
 
     def _write_spec(self, lines):

--- a/src/tito/distributionbuilder.py
+++ b/src/tito/distributionbuilder.py
@@ -44,7 +44,7 @@ class DistributionBuilder(UpstreamBuilder):
 
         for patch in self.patch_files:
             lines.insert(patch_insert_index, "Patch%s: %s\n" % (patch_number, patch))
-            lines.insert(patch_apply_index, "%%patch%s -p1\n" % (patch_number))
+            lines.insert(patch_apply_index, "%%patch %s -p1\n" % (patch_number))
             patch_number += 1
             patch_insert_index += 1
             patch_apply_index += 2


### PR DESCRIPTION
    RPM build warnings:
        %patchN is deprecated (1 usages found), use %patch N (or %patch -P N)