### PR TITLE
Use raw strings for regex patterns

### DIFF
--- a/src/tito/builder/fetch.py
+++ b/src/tito/builder/fetch.py
@@ -149,13 +149,13 @@ class ArgSourceStrategy(SourceStrategy):
             self.sources.append(dest_filepath)
 
             # Add a line to replace in the spec for each source:
-            source_regex = re.compile("^(source%s:\s*)(.+)$" % i, re.IGNORECASE)
+            source_regex = re.compile(r"^(source%s:\s*)(.+)$" % i, re.IGNORECASE)
             new_line = "Source%s: %s\n" % (i, base_name)
             replacements.append((source_regex, new_line))
 
         # Replace version and release in spec:
-        version_regex = re.compile("^(version:\s*)(.+)$", re.IGNORECASE)
-        release_regex = re.compile("^(release:\s*)(.+)$", re.IGNORECASE)
+        version_regex = re.compile(r"^(version:\s*)(.+)$", re.IGNORECASE)
+        release_regex = re.compile(r"^(release:\s*)(.+)$", re.IGNORECASE)
 
         (self.version, self.release) = self._get_version_and_release()
         print("Building version: %s" % self.version)
@@ -180,7 +180,7 @@ class ArgSourceStrategy(SourceStrategy):
         release = "1%{?dist}"
 
         # Example filename: tito-0.4.18.tar.gz:
-        simple_version_re = re.compile(".*-(.*).(tar.gz|tgz|zip|bz2)")
+        simple_version_re = re.compile(r".*-(.*).(tar.gz|tgz|zip|bz2)")
         match = re.search(simple_version_re, base_name)
         if match:
             version = match.group(1)

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -78,7 +78,7 @@ def extract_sources(spec_file_lines):
     location as the spec file, mostly used with NoTgzBuilder packages.
     """
     filenames = []
-    source_pattern = re.compile('^Source\d+?:\s*(.*)')
+    source_pattern = re.compile(r'^Source\d+?:\s*(.*)')
     for line in spec_file_lines:
         match = source_pattern.match(line)
         if match:
@@ -729,7 +729,7 @@ def replace_version(line, new_version):
     whitespace, and optional use of single/double quotes.
     """
     # Mmmmm pretty regex!
-    ver_regex = re.compile("(\s*)(version)(\s*)(=)(\s*)(['\"])(.*)(['\"])(.*)",
+    ver_regex = re.compile(r"(\s*)(version)(\s*)(=)(\s*)(['\"])(.*)(['\"])(.*)",
             re.IGNORECASE)
     m = ver_regex.match(line)
     if m:

--- a/src/tito/tagger/cargobump.py
+++ b/src/tito/tagger/cargobump.py
@@ -46,9 +46,9 @@ class CargoBump:
     @staticmethod
     def process_cargo_toml(input_string, new_version):
         file_buffer = []
-        pkg_label = re.compile('^\[package\]$')
-        label = re.compile('^\[.*\]$')
-        version = re.compile('(^version\s*=\s*)["\'](.+)["\'](.*$)')
+        pkg_label = re.compile(r'^\[package\]$')
+        label = re.compile(r'^\[.*\]$')
+        version = re.compile(r'(^version\s*=\s*)["\'](.+)["\'](.*$)')
         lines = [line.rstrip('\n') for line in input_string]
         state = 1
         for line in lines:

--- a/src/tito/tagger/main.py
+++ b/src/tito/tagger/main.py
@@ -74,8 +74,8 @@ class VersionTagger(ConfigObject):
         git_email = self.git_email
         if git_email is None:
             git_email = ''
-        self.changelog_regex = re.compile('\\*\s%s\s%s(\s<%s>)?' % (self.today,
-            self.git_user, git_email.replace("+", "\+").replace(".", "\.")))
+        self.changelog_regex = re.compile(r'\\*\s{0}\s{1}(\s<{2}>)?'.format(self.today,
+            self.git_user, git_email))
 
         self._no_auto_changelog = False
         self._accept_auto_changelog = False
@@ -178,7 +178,7 @@ class VersionTagger(ConfigObject):
         if not (self.config.has_option(BUILDCONFIG_SECTION, "changelog_do_not_remove_cherrypick")
             and self.config.get(BUILDCONFIG_SECTION, "changelog_do_not_remove_cherrypick")
             and self.config.get(BUILDCONFIG_SECTION, "changelog_do_not_remove_cherrypick").strip() != '0'):
-            m = re.match("(.+)(\(cherry picked from .*\))", line)
+            m = re.match(r"(.+)(\(cherry picked from .*\))", line)
             if m:
                 line = m.group(1)
         return line
@@ -394,8 +394,8 @@ class VersionTagger(ConfigObject):
         if old_version is None:
             old_version = "untagged"
         if not self.keep_version:
-            version_regex = re.compile("^(version:\s*)(.+)$", re.IGNORECASE)
-            release_regex = re.compile("^(release:\s*)(.+)$", re.IGNORECASE)
+            version_regex = re.compile(r"^(version:\s*)(.+)$", re.IGNORECASE)
+            release_regex = re.compile(r"^(release:\s*)(.+)$", re.IGNORECASE)
 
             in_f = open(self.spec_file, 'r')
             out_f = open(self.spec_file + ".new", 'w')

--- a/src/tito/tagger/rheltagger.py
+++ b/src/tito/tagger/rheltagger.py
@@ -37,7 +37,7 @@ class RHELTagger(ReleaseTagger):
             line = line.replace('%', '%%')
 
             # prepend Related/Resolves if subject contains BZ number
-            m = re.match("(\d+)\s+-\s+(.*)", line)
+            m = re.match(r"(\d+)\s+-\s+(.*)", line)
             if m:
                 bz_number = m.group(1)
                 if bz_number in BZ:

--- a/src/tito/tagger/susetagger.py
+++ b/src/tito/tagger/susetagger.py
@@ -41,8 +41,8 @@ class SUSETagger(VersionTagger):
         self.changes_file = os.path.join(self.full_project_dir,
                 self.changes_file_name)
         self._new_changelog_msg = "Initial package release"
-        self.changelog_regex = re.compile('^\s%s\s%s(\s<%s>)?' % (self.today,
-            self.git_user, self.git_email.replace("+", "\+").replace(".", "\.")))
+        self.changelog_regex = re.compile(r'^\s{0}\s{1}(\s<{2}>)?'.format(self.today,
+            self.git_user, self.git_email))
 
     def _make_changelog(self):
         """
@@ -135,7 +135,7 @@ class SUSETagger(VersionTagger):
         buf = StringIO()
         found_match = False
         done = False
-        empty_line_regex = re.compile('^\s*$')
+        empty_line_regex = re.compile(r'^\s*$')
 
         for line in f.readlines():
             if not done and not found_match and self.changelog_regex.match(line):

--- a/src/tito/tar.py
+++ b/src/tito/tar.py
@@ -184,7 +184,7 @@ class TarFixer(object):
             if member in self.octal_members:
                 # Pad out the octal value to the right length
                 member_template = self.struct_hash[member]
-                field_size = int(re.match('(\d+)', member_template).group(1)) - 1
+                field_size = int(re.match(r'(\d+)', member_template).group(1)) - 1
                 fmt = "%0" + str(field_size) + "o\x00"
                 as_string = fmt % chunk_props[member]
                 pack_values.append(tito.compat.ensure_binary(as_string))


### PR DESCRIPTION
I am fixing the following syntax warnings and more.

/home/jkadlcik/git/tito/src/tito/common.py:81: SyntaxWarning: invalid escape sequence '\d'
  source_pattern = re.compile('^Source\d+?:\s*(.*)')
/home/jkadlcik/git/tito/src/tito/common.py:732: SyntaxWarning: invalid escape sequence '\s'
  ver_regex = re.compile("(\s*)(version)(\s*)(=)(\s*)(['\"])(.*)(['\"])(.*)",
/home/jkadlcik/git/tito/src/tito/tar.py:187: SyntaxWarning: invalid escape sequence '\d'
  field_size = int(re.match('(\d+)', member_template).group(1)) - 1