### PR TITLE
chore: add new issues into the CPT's Kanban

### DIFF
--- a/.github/workflows/new-issues-to-board.yml
+++ b/.github/workflows/new-issues-to-board.yml
@@ -1,0 +1,15 @@
+---
+name: Move new issues to issues review
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  move-new-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/fedora-copr/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
This commit requires specifying the ADD_TO_PROJECT_PAT secret - already done.