### PR TITLE
Building in non-initialized project without explicit parameter

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -476,7 +476,7 @@ class Builder(ConfigObject, BuilderBase):
                     error_out(["Unable to lookup latest package info.",
                                "Perhaps you need to tag first?"])
                 if not self.without_init:
-                    warn_out("unable to lookup latest package "
+                    warn_out("Unable to lookup latest package "
                              "tag, building untagged test project")
                 build_version = get_spec_version_and_release(self.start_dir,
                     find_spec_like_file(self.start_dir))

--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -101,7 +101,8 @@ class BuilderBase(object):
         if args and 'test' in args:
             self.test = True
 
-        self.without_init = self._get_optional_arg(kwargs, "without_init", False)
+        self.ignore_missing_config = \
+            self._get_optional_arg(kwargs, "ignore_missing_config", False)
 
         # Location where we do all tito work and store resulting rpms:
         self.rpmbuild_basedir = build_dir
@@ -419,7 +420,7 @@ class Builder(ConfigObject, BuilderBase):
         self.relative_project_dir = get_relative_project_dir(
             project_name=self.project_name, commit=self.git_commit_id)
         if self.relative_project_dir is None and self.test:
-            if not self.without_init:
+            if not self.ignore_missing_config:
                 warn_out(".tito/packages/%s doesn't exist "
                     "in git, using current directory" % self.project_name)
             self.relative_project_dir = get_relative_project_dir_cwd(
@@ -475,7 +476,7 @@ class Builder(ConfigObject, BuilderBase):
                 if not self.test:
                     error_out(["Unable to lookup latest package info.",
                                "Perhaps you need to tag first?"])
-                if not self.without_init:
+                if not self.ignore_missing_config:
                     warn_out("Unable to lookup latest package "
                              "tag, building untagged test project")
                 build_version = get_spec_version_and_release(self.start_dir,

--- a/src/tito/cli.py
+++ b/src/tito/cli.py
@@ -293,10 +293,10 @@ class BaseCliModule(object):
             error_out("Unable to locate branch configuration: %s\n"
                       "Please run 'tito init'" % loader.tito_props_path)
 
-        if not self.options.without_init:
+        if not self.options.ignore_missing_config:
             warn_out("Tito project wasn't initialized, "
                      "using the default configuration")
-            warn_out("Consider `tito init' or the `--without-init' "
+            warn_out("Consider `tito init' or the `--ignore-missing-config' "
                      "parameter to silent the warnings")
 
         self.config = self.initial_config
@@ -366,7 +366,7 @@ class BuildModule(BaseCliModule):
 
         self.parser.add_option("--test", dest="test", action="store_true",
                 help="use current branch HEAD instead of latest package tag")
-        self.parser.add_option("--without-init", action="store_true",
+        self.parser.add_option("--ignore-missing-config", action="store_true",
                 help=("Acknowledge working in non-initialized project "
                       "and silencing all related warnings"))
         self.parser.add_option("--no-cleanup", dest="no_cleanup",
@@ -415,7 +415,7 @@ class BuildModule(BaseCliModule):
         kwargs = {
             'dist': self.options.dist,
             'test': self.options.test,
-            'without_init': self.options.without_init,
+            'ignore_missing_config': self.options.ignore_missing_config,
             'offline': self.options.offline,
             'auto_install': self.options.auto_install,
             'rpmbuild_options': self.options.rpmbuild_options,


### PR DESCRIPTION
Fix #472

Now, it is possible to build packages without using any parameters.

```
$ tito --srpm --test
Creating output directory: /tmp/tito
WARNING: Tito project wasn't initialized,using the default configuration
WARNING: Consider `tito init' or the `--without-init' parameter to silent the warnings
WARNING: Unable to lookup latest package tag, building untagged test project
WARNING: .tito/packages/tito doesn't exist in git, using current directory
Building package [tito-0.6.24-1]
Wrote: /tmp/tito/tito-git-9.1e9ec0b.tar.gz

setting SOURCE_DATE_EPOCH=1688774400
Wrote: /tmp/tito/tito-0.6.24-1.git.9.1e9ec0b.fc39.src.rpm
```

To silence the warnings, it is possible to use the `--without-init` parameter

```
$ tito build --srpm --test --without-init
Creating output directory: /tmp/tito
Building package [tito-0.6.24-1]
Wrote: /tmp/tito/tito-git-9.1e9ec0b.tar.gz

setting SOURCE_DATE_EPOCH=1688774400
Wrote: /tmp/tito/tito-0.6.24-1.git.9.1e9ec0b.fc39.src.rpm
```

If the `.tito` directory exists, the `--without-init` parameter does nothing. So when integrating into Copr, the `--wihout-init` parameter can be used every time for every project. But maybe we should rename it to `--ignore-missing-init`, `--ignore-missing-config`, `--ignore-init-warnings`, or something like that?

One more thing that I realized is that we can only build in non-initialized projects when using `--test`. Without it, we get

```
$ tito build --srpm
Creating output directory: /tmp/tito
WARNING: Tito project wasn't initialized,using the default configuration
WARNING: Consider `tito init' or the `--without-init' parameter to silent the warnings
ERROR: Unable to lookup latest package info.
Perhaps you need to tag first?
```

We will need that for Copr, right @praiskup?