### PR TITLE
Fix a runtime SyntaxWarning with Python 3.12

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -868,8 +868,8 @@ class UpstreamBuilder(NoTgzBuilder):
         lines = f.readlines()
         f.close()
 
-        patch_pattern = re.compile('^Patch(\d+):')
-        source_pattern = re.compile('^Source(\d+)?:')
+        patch_pattern = re.compile(r'^Patch(\d+):')
+        source_pattern = re.compile(r'^Source(\d+)?:')
 
         # Find the largest PatchX: line, or failing that SourceX:
         patch_number = 0  # What number should we use for our PatchX line


### PR DESCRIPTION
Creating output directory: /tmp/tito
src/tito/builder/main.py:871: SyntaxWarning: invalid escape sequence '\d'
  patch_pattern = re.compile('^Patch(\d+):')
src/tito/builder/main.py:872: SyntaxWarning: invalid escape sequence '\d'
  source_pattern = re.compile('^Source(\d+)?:')
Building package [tito-0.6.25-1]
Wrote: /tmp/tito/tito-git-2.909184d.tar.gz