### PR TITLE
New config option `buildconfig.test_version_suffix`

### DIFF
--- a/src/tito/builder/main.py
+++ b/src/tito/builder/main.py
@@ -86,6 +86,9 @@ class BuilderBase(object):
             config_fetch_default = self.config.get(BUILDCONFIG_SECTION, "fetch_sources")
         self.fetch_sources = self._get_optional_arg(kwargs, 'fetch_sources', config_fetch_default)
 
+        self.test_version_suffix = self.config.get(
+                BUILDCONFIG_SECTION, "test_version_suffix", fallback="")
+
         rpmbuildopts = self._get_optional_arg(args, 'rpmbuild_options', None)
         if rpmbuildopts:
             self.rpmbuild_options = ' '.join(rpmbuildopts)
@@ -642,6 +645,7 @@ class Builder(ConfigObject, BuilderBase):
                 self.commit_count,
                 fullname,
                 self.tgz_filename,
+                self.test_version_suffix,
             )
 
             self.build_version += ".git." + str(self.commit_count) + "." + str(sha)

--- a/src/tito/common.py
+++ b/src/tito/common.py
@@ -585,7 +585,8 @@ def replace_spec_release(file_name, release):
             print(line.rstrip('\n'))
 
 
-def munge_specfile(spec_file, commit_id, commit_count, fullname=None, tgz_filename=None):
+def munge_specfile(spec_file, commit_id, commit_count, fullname=None,
+                   tgz_filename=None, version_suffix=None):
     # If making a test rpm we need to get a little crazy with the spec
     # file we're building off. (Note we are modifying a temp copy of the
     # spec) Swap out the actual release for one that includes the git
@@ -603,6 +604,12 @@ def munge_specfile(spec_file, commit_id, commit_count, fullname=None, tgz_filena
                 m.group(3) or '',
             ))
             continue
+
+        if version_suffix:
+            m = re.match(r'^(\s*Version:\s*)(.+?)\s*$', line)
+            if m:
+                print(m.group(1) + m.group(2) + version_suffix)
+                continue
 
         m = re.match(r'^(\s*Source0?):\s*(.+?)$', line)
         if tgz_filename and m:

--- a/tito.props.5.asciidoc
+++ b/tito.props.5.asciidoc
@@ -98,6 +98,13 @@ fetch_sources::
 If true, download sources from predefined Source<N> addresses to the
 SOURCE folder.
 
+test_version_suffix::
+Append a given suffix (string, e.g., `.post`) to the `Version:` tag in the
+generated spec file when building with `--test`. This ensures that any `--test`
+NEVRA is higher than the NEVRA of the previous release. Simply modifying the
+`Release:` tag doesn't guarantee this, as downstream `Release:` numbers are
+often incremented, which would take precedence (e.g., `foo-1.0-1.git.3.60fe05a`
+< `foo-1.0-2`).
 
 KOJI and COPR
 -------------


### PR DESCRIPTION
If configured like

    $ cat .tito/tito.props
    [buildconfig]
    test_version_suffix = .tito.git

The `tito build --test ...` NEVRA is always higher than the NEVRA of released RPMs.

Fixes: #460