### PR TITLE
builder: defer submodule detection to git

### DIFF
--- a/src/tito/builder/submodule_aware_builder.py
+++ b/src/tito/builder/submodule_aware_builder.py
@@ -152,12 +152,12 @@ class SubmoduleAwareBuilder(Builder):
         timestamp = get_commit_timestamp(commit)
 
         # Accommodate standalone projects with specfile in root of git repo:
-        relative_git_dir = "%s" % relative_dir
+        relative_git_dir = str(relative_dir)
         if relative_git_dir in ["/", "./"]:
             relative_git_dir = ""
 
         basename = os.path.splitext(dest_tgz)[0]
-        initial_tar = "%s.initial" % basename
+        initial_tar = "{0}.initial".format(basename)
 
         # We need to tar up the following:
         # 1. the current repo
@@ -166,11 +166,11 @@ class SubmoduleAwareBuilder(Builder):
         # 2. all of the submodules
         # then combine those into a single archive.
         for submodule_tar_file in self._submodule_archives(
-            relative_git_dir, prefix, commit, initial_tar
+            relative_git_dir, prefix, initial_tar
         ):
-            run_command("tar -Af %s %s" % (initial_tar, submodule_tar_file))
+            run_command("tar -Af {0} {1}".format(initial_tar, submodule_tar_file))
 
-        fixed_tar = "%s.tar" % basename
+        fixed_tar = "{0}.tar".format(basename)
         fixed_tar_fh = open(fixed_tar, "wb")
         try:
             tarfixer = TarFixer(
@@ -181,4 +181,4 @@ class SubmoduleAwareBuilder(Builder):
             fixed_tar_fh.close()
 
         # It's a pity we can't use Python's gzip, but it doesn't offer an equivalent of -n
-        return run_command("gzip -n -c < %s > %s" % (fixed_tar, dest_tgz))
+        return run_command("gzip -n -c < {0} > {1}".format(fixed_tar, dest_tgz))

--- a/src/tito/builder/submodule_aware_builder.py
+++ b/src/tito/builder/submodule_aware_builder.py
@@ -27,7 +27,6 @@ from tito.common import (
     find_spec_like_file,
     get_commit_timestamp,
 )
-from tito.exception import TitoException
 from tito.tar import TarFixer
 
 
@@ -109,54 +108,31 @@ class SubmoduleAwareBuilder(Builder):
                 "%s > /dev/null" % git_archive_cmd,
             )
 
-    # pylint: disable=too-many-locals, too-many-arguments, consider-using-f-string
-    def _submodule_archives(self, relative_git_dir, prefix, commit, initial_tar,
-                            submodule_tree="."):
-        with chdir(submodule_tree):
-            submodules_cmd = "git config --file .gitmodules --get-regexp path"
-            submodules_output = run_command(submodules_cmd)
+    def _submodule_archives(self, relative_git_dir, prefix, initial_tar, source_tree="."):
+        with chdir(source_tree):
+            # Let git handle edge cases for .gitmodules (eg: empty files etc)
+            submodules_status_cmd = "git submodule status --recursive"
+            submodules_status_output = run_command(submodules_status_cmd)
 
-        # split submodules output on newline
-        # then on tab, and the directory is the last entry
-        submodules_list = [
-            line.split(" ")[-1] for line in submodules_output.split("\n")
-        ]
+        for line in submodules_status_output.strip().split("\n"):
+            row = line.split()
+            submodule_commit, submodule_relative_dir = row[0], row[1]
 
-        # We ignore the hash in the sub modules list as we'll have to get the correct one
-        # from the commit id in commit
-        for submodule in submodules_list:
-            with chdir(submodule_tree):
-                submodule_git_dir = os.path.join(submodule, ".git")
-                if not os.path.exists(submodule_git_dir):
-                    raise TitoException("%r path does not contain '.git'. "
-                                        "Have you cloned the repository recursively?\n"
-                                        "Try `git submodule update --init --recursive`!" %
-                                        os.path.abspath(submodule))
-                # to find the submodule shars:
-                # git rev-parse <commit>:./<submodule>
-                rev_parse_cmd = "git rev-parse %s:./%s" % (commit, submodule)
-                submodule_commit = run_command(rev_parse_cmd)
-                submodule_tar_file = "%s.%s" % (initial_tar, submodule.replace("/", "_"))
-                # prefix should be <prefix>/<submodule>
-                submodule_prefix = "%s/%s" % (prefix, submodule)
+            submodule_tar_file_suffix = submodule_relative_dir.replace("/", "_")
+            submodule_tar_file = "{0}.{1}".format(initial_tar, submodule_tar_file_suffix)
 
-                self.run_git_archive(
-                    relative_git_dir,
-                    submodule_prefix,
-                    submodule_commit,
-                    submodule_tar_file,
-                    submodule,
-                )
-            yield (submodule_tar_file)
+            # prefix should be <prefix>/<submodule>
+            submodule_prefix = "{0}/{1}".format(prefix, submodule_relative_dir)
 
-            submodule_dir = os.path.join(submodule_tree, submodule)
-            gitmodules_path = os.path.join(submodule_dir, ".gitmodules")
-            if os.path.exists(gitmodules_path):
-                for archive in self._submodule_archives(
-                        relative_git_dir, submodule_prefix, submodule_commit,
-                        submodule_tar_file, submodule_dir
-                ):
-                    yield archive
+            self.run_git_archive(
+                relative_git_dir,
+                submodule_prefix,
+                submodule_commit,
+                submodule_tar_file,
+                submodule_relative_dir,
+            )
+
+            yield submodule_tar_file
 
     def create_tgz(self, git_root, prefix, commit, relative_dir, dest_tgz):
         """


### PR DESCRIPTION
Recent builds on copr started failing for rpms using submodule aware builders, see logs below. The root cause for the issue was the presence of an empty `.gitmodules` file in a submodule. The recursion logic currently only checks if the file exists, if it does, tries to fetch the paths using the `git config --file .gitmodules --get-regexp path` command. Which exits with status code `1` when the `.gitmodules` file is empty.

I have tried to work around this issue by deferring the logic of identifying all nested submodules to `git submodule status --recursive` instead. Which allows for a less complex handling within tito. Ideally, I reckon this could even be simplified further by use of either the `git submodules foreach 'git archive ...'` command or  `git ls-files --recurse-submodules` and piping those files into the `tarfile` module. But for now, I have kept the change trivial and attempted to keep the interface change to a minimum.

Please let me know if I need to fix/add anything.

<details>
<summary><b>copr-build.log</b></summary>
<p>

```console
Running: tito build --srpm --output /var/lib/copr-rpmbuild/results

cmd: ['tito', 'build', '--srpm', '--output', '/var/lib/copr-rpmbuild/results']
cwd: /var/lib/copr-rpmbuild/workspace/workdir-lc93u41j/web-eid-rpm
rc: 1
stdout: Creating output directory: /var/lib/copr-rpmbuild/results
Checking for tag [web-eid-2.6.0-1] in git repo [https://github.com/abn/web-eid-rpm.git]
Building package [web-eid-2.6.0-1]
stderr: ERROR: Error running command: git config --file .gitmodules --get-regexp path

Status code: 1

Command output: 

Traceback (most recent call last):
  File "/usr/bin/tito", line 33, in <module>
    sys.exit(load_entry_point('tito==0.6.26', 'console_scripts', 'tito')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/cli.py", line 944, in main
    CLI().main(sys.argv[1:])
  File "/usr/lib/python3.12/site-packages/tito/cli.py", line 210, in main
    return module.main(argv)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/cli.py", line 432, in main
    return builder.run(self.options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/builder/main.py", line 165, in run
    self.srpm()
  File "/usr/lib/python3.12/site-packages/tito/builder/main.py", line 224, in srpm
    self.tgz()
  File "/usr/lib/python3.12/site-packages/tito/builder/main.py", line 578, in tgz
    self._setup_sources()
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 61, in _setup_sources
    self.create_tgz(
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 192, in create_tgz
    for submodule_tar_file in self._submodule_archives(
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 155, in _submodule_archives
    for archive in self._submodule_archives(
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 155, in _submodule_archives
    for archive in self._submodule_archives(
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 117, in _submodule_archives
    submodules_output = run_command(submodules_cmd)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/common.py", line 305, in run_command
    raise RunCommandException(command, status, output)
tito.exception.RunCommandException: Error running command: git config --file .gitmodules --get-regexp path

Copr build error: ERROR: Error running command: git config --file .gitmodules --get-regexp path

Status code: 1

Command output: 

Traceback (most recent call last):
  File "/usr/bin/tito", line 33, in <module>
    sys.exit(load_entry_point('tito==0.6.26', 'console_scripts', 'tito')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/cli.py", line 944, in main
    CLI().main(sys.argv[1:])
  File "/usr/lib/python3.12/site-packages/tito/cli.py", line 210, in main
    return module.main(argv)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/cli.py", line 432, in main
    return builder.run(self.options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/builder/main.py", line 165, in run
    self.srpm()
  File "/usr/lib/python3.12/site-packages/tito/builder/main.py", line 224, in srpm
    self.tgz()
  File "/usr/lib/python3.12/site-packages/tito/builder/main.py", line 578, in tgz
    self._setup_sources()
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 61, in _setup_sources
    self.create_tgz(
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 192, in create_tgz
    for submodule_tar_file in self._submodule_archives(
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 155, in _submodule_archives
    for archive in self._submodule_archives(
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 155, in _submodule_archives
    for archive in self._submodule_archives(
  File "/usr/lib/python3.12/site-packages/tito/builder/submodule_aware_builder.py", line 117, in _submodule_archives
    submodules_output = run_command(submodules_cmd)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/tito/common.py", line 305, in run_command
    raise RunCommandException(command, status, output)
tito.exception.RunCommandException: Error running command: git config --file .gitmodules --get-regexp path
```

</p>
</details>