### PR TITLE
tox: drop Python 3.7 add 3.9

### DIFF
--- a/.github/workflows/fedora-tox.yml
+++ b/.github/workflows/fedora-tox.yml
@@ -39,8 +39,7 @@ jobs:
         tox_env:
           # sync with /tox.ini
           - py36
-          - py37
-          - py311
+          - py39
           - py312
           - py313
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ max-line-length=120
 
 [tox]
 # sync with /.github/workflows/fedora-tox.yml
-envlist = py{36,37,311,312,313}
+# EL8 v3.6, EL9 v3.9, EL10 v3.12.
+envlist = py{36,39,312,313}
 skipsdist = True
 
 


### PR DESCRIPTION
No longer provided in the testing environment.